### PR TITLE
fixes datastore for earlier steps

### DIFF
--- a/2-cloud-datastore/app/models/book.rb
+++ b/2-cloud-datastore/app/models/book.rb
@@ -54,7 +54,7 @@ class Book
     book = Book.new
     book.id = entity.key.id
     entity.properties.to_hash.each do |name, value|
-      book.send "#{name}=", value
+      book.send "#{name}=", value if book.respond_to? "#{name}="
     end
     book
   end

--- a/3-cloud-storage/structured_data/datastore/app/models/book.rb
+++ b/3-cloud-storage/structured_data/datastore/app/models/book.rb
@@ -55,7 +55,7 @@ class Book
     book = Book.new
     book.id = entity.key.id
     entity.properties.to_hash.each do |name, value|
-      book.send "#{name}=", value
+      book.send "#{name}=", value if book.respond_to? "#{name}="
     end
     book
   end

--- a/4-auth/structured_data/datastore/app/models/book.rb
+++ b/4-auth/structured_data/datastore/app/models/book.rb
@@ -61,7 +61,7 @@ class Book
     book = Book.new
     book.id = entity.key.id
     entity.properties.to_hash.each do |name, value|
-      book.send "#{name}=", value
+      book.send "#{name}=", value if book.respond_to? "#{name}="
     end
     book
   end

--- a/5-logging/structured_data/datastore/app/models/book.rb
+++ b/5-logging/structured_data/datastore/app/models/book.rb
@@ -61,7 +61,7 @@ class Book
     book = Book.new
     book.id = entity.key.id
     entity.properties.to_hash.each do |name, value|
-      book.send "#{name}=", value
+      book.send "#{name}=", value if book.respond_to? "#{name}="
     end
     book
   end

--- a/6-task-queueing/structured_data/datastore/app/models/book.rb
+++ b/6-task-queueing/structured_data/datastore/app/models/book.rb
@@ -60,7 +60,7 @@ class Book
     book = Book.new
     book.id = entity.key.id
     entity.properties.to_hash.each do |name, value|
-      book.send "#{name}=", value
+      book.send "#{name}=", value if book.respond_to? "#{name}="
     end
     book
   end
@@ -151,7 +151,7 @@ class Book
         self.id = entity.key.id
         lookup_book_details
       end
-     
+
       self.id = entity.key.id
       update_image if cover_image.present?
       true


### PR DESCRIPTION
This fixes the error `undefined method image_url=` from being thrown when an entity created in a later step (with an image URL) is queried and populated by an earlier step (when the property doesn't exist yet).

Rather than throw an exception, the `book.rb` datastiore model now just ignores unrecognized fields in the entity.