### PR TITLE
Remove license header from Dockerfile.

### DIFF
--- a/optional-container-engine/Dockerfile
+++ b/optional-container-engine/Dockerfile
@@ -1,16 +1,3 @@
-# Copyright 2016, Google, Inc.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # The Google App Engine Ruby runtime is Debian Jessie with Ruby installed
 # and various os-level packages to allow installation of popular Ruby
 # gems. The source is on github at:


### PR DESCRIPTION
Other languages don't use a header in the Dockerfile and the git-include needs to be the same.