### PR TITLE
Fixing worker failure when no book is found

### DIFF
--- a/6-task-queueing/spec/models/book_spec.rb
+++ b/6-task-queueing/spec/models/book_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe Book do
     allow(book_service).to receive(:authorization=)
     expect(book_service).to receive(:list_volumes).with(
       "A Tale of Two Cities", order_by: "relevance"
-    ).and_yield(double(items: [book_response]), nil)
+    ).and_yield(double(total_items: 1, items: [book_response]), nil)
 
     allow(Google::Apis::BooksV1::BooksService).to receive(:new).
-                                               and_return book_service
+                                                  and_return book_service
 
     run_enqueued_jobs!
 

--- a/6-task-queueing/spec/models/book_spec.rb
+++ b/6-task-queueing/spec/models/book_spec.rb
@@ -58,39 +58,15 @@ RSpec.describe Book do
     expect(job[:job]).to eq LookupBookDetailsJob
     expect(job[:args]).to eq [{ "_aj_globalid" => book.to_global_id.to_s }]
 
-    # Mock Books API RPC method
-    book_service = double
-
-    # Mock response from call to Books API
-    book_response = double(
-      self_link: "https://link/to/book",
-      volume_info: double(
-        title: "A Tale of Two Cities",
-        authors: ["Charles Dickens"],
-        published_date: "1859",
-        description: "A Tale of Two Cities is a novel by Charles Dickens.",
-        image_links: double(thumbnail: "https://path/to/cover/image.png")
-      )
-    )
-
-    allow(book_service).to receive(:authorization=)
-    expect(book_service).to receive(:list_volumes).with(
-      "A Tale of Two Cities", order_by: "relevance"
-    ).and_yield(double(total_items: 1, items: [book_response]), nil)
-
-    allow(Google::Apis::BooksV1::BooksService).to receive(:new).
-                                                  and_return book_service
-
     run_enqueued_jobs!
 
     expect(enqueued_jobs).to be_empty
 
-    book.reload
+    book = Book.find book.id
     expect(book.title).to eq "A Tale of Two Cities"
     expect(book.author).to eq "Charles Dickens"
-    expect(book.published_on.to_date).to eq Date.parse("1859-01-01")
-    expect(book.description).to eq "A Tale of Two Cities is a novel by Charles Dickens."
-    expect(book.image_url).to eq "https://path/to/cover/image.png"
+    expect(book.description).to include "Charles Dickens' classic novel"
+    expect(book.image_url).to eq "http://books.google.com/books/content?id=5EIPAAAAQAAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
   end
 
   it "book details are only looked up when fields are blank"

--- a/7-compute-engine/app/jobs/lookup_book_details_job.rb
+++ b/7-compute-engine/app/jobs/lookup_book_details_job.rb
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START lookup_books]
 require "google/apis/books_v1"
 
 BooksAPI = Google::Apis::BooksV1
@@ -44,8 +43,7 @@ class LookupBookDetailsJob < ActiveJob::Base
 
       # List of relevant books
       volumes = results.items
-# [END lookup_books]
-      # [START choose_volume]
+
       # To provide the best results, find the first returned book that
       # includes title and author information as well as a book cover image.
       best_match = volumes.find {|volume|
@@ -54,9 +52,7 @@ class LookupBookDetailsJob < ActiveJob::Base
       }
 
       volume = best_match || volumes.first
-      # [END choose_volume]
 
-      # [START update_book]
       if volume
         info   = volume.volume_info
         images = info.image_links
@@ -72,10 +68,8 @@ class LookupBookDetailsJob < ActiveJob::Base
                                                                present?
         book.save
       end
-      # [END update_book]
 
       Rails.logger.info "[BookService] (#{book.id}) Complete"
     end
   end
 end
-# [END book_lookup]

--- a/7-compute-engine/app/jobs/lookup_book_details_job.rb
+++ b/7-compute-engine/app/jobs/lookup_book_details_job.rb
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START lookup_books]
 require "google/apis/books_v1"
 
 BooksAPI = Google::Apis::BooksV1
@@ -19,22 +20,32 @@ class LookupBookDetailsJob < ActiveJob::Base
   queue_as :default
 
   def perform book
-    Rails.logger.info "Lookup details for book #{book.id} #{book.title.inspect}"
+    Rails.logger.info "[BookService] Lookup details for book" +
+                      "#{book.id} #{book.title.inspect}"
 
     # Create Book API Client
     book_service = BooksAPI::BooksService.new
-    book_service.authorization = nil # Books API does not require authentication
+    # Books API does not require authentication
+    book_service.authorization = nil
 
     # Lookup a list of relevant books based on the provided book title.
     book_service.list_volumes book.title, order_by: "relevance" do |results, error|
+      # Error ocurred soft-failure
       if error
-        Rails.logger.error "[BookService] " + error
-        raise "BookService list_volumes ERROR!"
+        Rails.logger.error "[BookService] #{error.inspect}"
+        break
+      end
+
+      # Book was not found
+      if results.total_items.zero?
+        Rails.logger.info "[BookService] #{book.title} was not found."
+        break
       end
 
       # List of relevant books
       volumes = results.items
-
+# [END lookup_books]
+      # [START choose_volume]
       # To provide the best results, find the first returned book that
       # includes title and author information as well as a book cover image.
       best_match = volumes.find {|volume|
@@ -43,7 +54,9 @@ class LookupBookDetailsJob < ActiveJob::Base
       }
 
       volume = best_match || volumes.first
+      # [END choose_volume]
 
+      # [START update_book]
       if volume
         info   = volume.volume_info
         images = info.image_links
@@ -53,13 +66,16 @@ class LookupBookDetailsJob < ActiveJob::Base
         publication_date = Date.parse publication_date
 
         book.author       = info.authors.join(", ") unless book.author.present?
-        book.published_on = publication_date     unless book.published_on.present?
-        book.description  = info.description        unless book.description.present?
-        book.image_url    = images.try(:thumbnail)  unless book.image_url.present?
+        book.published_on = publication_date unless book.published_on.present?
+        book.description  = info.description unless book.description.present?
+        book.image_url    = images.try(:thumbnail) unless book.image_url.
+                                                               present?
         book.save
       end
+      # [END update_book]
 
-      Rails.logger.info "(#{book.id}) Complete"
+      Rails.logger.info "[BookService] (#{book.id}) Complete"
     end
   end
 end
+# [END book_lookup]


### PR DESCRIPTION
Referencing issue: #72 

When a gibberish name is used for a new book the worker would crash. This PR updates the code to fail gracefully with an error message instead of a crash. 