### PR TITLE
Upgrade to "google-cloud" gem.

### DIFF
--- a/6-task-queueing/Gemfile
+++ b/6-task-queueing/Gemfile
@@ -19,7 +19,7 @@ gem "fog"
 gem "omniauth"
 gem "omniauth-google-oauth2"
 # [START gcloud]
-gem "gcloud"
+gem "google-cloud"
 # [END gcloud]
 # [START google_api_client]
 gem "google-api-client", "~> 0.9"

--- a/6-task-queueing/Gemfile.lock
+++ b/6-task-queueing/Gemfile.lock
@@ -186,8 +186,6 @@ GEM
     foreman (0.82.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
-    gcloud (0.21.0)
-      google-cloud (~> 0.21.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     google-api-client (0.9.20)
@@ -450,8 +448,8 @@ DEPENDENCIES
   capybara
   fog
   foreman
-  gcloud
   google-api-client (~> 0.9)
+  google-cloud
   jquery-rails
   mysql2 (~> 0.3.0)
   omniauth
@@ -464,4 +462,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.13.4
+   1.14.2


### PR DESCRIPTION
Previously, this was using `gcloud` which is no longer preferred.

This brings it inline with the rest of the Gemfile's in the project.