### PR TITLE
Fork off fog storage tutorial in preparation for dropping fog in main

### DIFF
--- a/3-cloud-storage-fog/.dockerignore
+++ b/3-cloud-storage-fog/.dockerignore
@@ -1,0 +1,16 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.git
+log/*
+tmp/*

--- a/3-cloud-storage-fog/.gitignore
+++ b/3-cloud-storage-fog/.gitignore
@@ -1,0 +1,22 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/.bundle
+/log/*
+/tmp
+/public/assets/
+config/database.yml
+config/settings.yml
+*.sqlite3
+/config/database.yml
+/gcd_dataset_directory/

--- a/3-cloud-storage-fog/CONTRIBUTING.md
+++ b/3-cloud-storage-fog/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# How to become a contributor and submit your own code
+
+## Contributor License Agreements
+
+We'd love to accept your patches! Before we can take them, we
+have to jump a couple of legal hurdles.
+
+Please fill out either the individual or corporate Contributor License Agreement
+(CLA).
+
+  * If you are an individual writing original source code and you're sure you
+    own the intellectual property, then you'll need to sign an [individual CLA]
+    (https://developers.google.com/open-source/cla/individual).
+  * If you work for a company that wants to allow you to contribute your work,
+    then you'll need to sign a [corporate CLA]
+    (https://developers.google.com/open-source/cla/corporate).
+
+Follow either of the two links above to access the appropriate CLA and
+instructions for how to sign and return it. Once we receive it, we'll be able to
+accept your pull requests.
+
+## Contributing A Patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The repo owner will respond to your issue promptly.
+1. If your proposed change is accepted, and you haven't already done so, sign a
+   Contributor License Agreement (see details above).
+1. Fork the desired repo, develop and test your code changes.
+1. Ensure that your code adheres to the existing style in the sample to which
+   you are contributing. Refer to the
+   [Google Cloud Platform Samples Style Guide]
+   (https://github.com/GoogleCloudPlatform/Template/wiki/style.html) for the
+   recommended coding standards for this organization.
+1. Ensure that your code has an appropriate set of unit tests which all pass.
+1. Submit a pull request.

--- a/3-cloud-storage-fog/Gemfile
+++ b/3-cloud-storage-fog/Gemfile
@@ -1,0 +1,39 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+
+gem "rails", "~> 4.2.8"
+gem "google-cloud-datastore"
+gem "jquery-rails"
+#[START fog]
+gem "fog"
+#[END fog]
+
+group :production do
+  gem "mysql2", "~> 0.3.0"
+end
+
+group :development, :test do
+  gem "sqlite3"
+end
+
+# For Windows support
+gem "tzinfo-data"
+
+group :test do
+  gem "rspec-rails"
+  gem "rack-test"
+  gem "capybara"
+  gem "poltergeist"
+end

--- a/3-cloud-storage-fog/Gemfile.lock
+++ b/3-cloud-storage-fog/Gemfile.lock
@@ -1,0 +1,347 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.3)
+    actionmailer (4.2.10)
+      actionpack (= 4.2.10)
+      actionview (= 4.2.10)
+      activejob (= 4.2.10)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (4.2.10)
+      actionview (= 4.2.10)
+      activesupport (= 4.2.10)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.10)
+      activesupport (= 4.2.10)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (4.2.10)
+      activesupport (= 4.2.10)
+      globalid (>= 0.3.0)
+    activemodel (4.2.10)
+      activesupport (= 4.2.10)
+      builder (~> 3.1)
+    activerecord (4.2.10)
+      activemodel (= 4.2.10)
+      activesupport (= 4.2.10)
+      arel (~> 6.0)
+    activesupport (4.2.10)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    arel (6.0.4)
+    builder (3.2.3)
+    capybara (2.10.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    cliver (0.3.2)
+    concurrent-ruby (1.0.5)
+    crass (1.0.3)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    excon (0.54.0)
+    faraday (0.10.0)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.38.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
+      fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.12.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.11.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-openstack (0.1.17)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-rackspace (0.1.2)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (1.5.1)
+      fog-core
+      rbvmomi (~> 1.9)
+    fog-xenserver (0.2.3)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    globalid (0.4.1)
+      activesupport (>= 4.2.0)
+    google-cloud-core (0.21.0)
+    google-cloud-datastore (0.21.0)
+      google-cloud-core (~> 0.21.0)
+      google-gax (~> 0.6.0)
+      google-protobuf (~> 3.0)
+      googleapis-common-protos (~> 1.3)
+      grpc (~> 1.0)
+    google-gax (0.6.0)
+      googleapis-common-protos (~> 1.3.1)
+      googleauth (~> 0.5.1)
+      grpc (~> 1.0)
+      rly (~> 0.2.3)
+    google-protobuf (3.0.2)
+    googleapis-common-protos (1.3.4)
+      google-protobuf (~> 3.0)
+      grpc (~> 1.0)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    grpc (1.0.1)
+      google-protobuf (~> 3.0.2)
+      googleauth (~> 0.5.1)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.3)
+    jquery-rails (4.2.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    json (2.1.0)
+    jwt (1.5.6)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
+    memoist (0.15.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
+    minitest (5.10.3)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    mysql2 (0.3.21)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    os (0.9.6)
+    poltergeist (1.11.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
+    public_suffix (2.0.4)
+    rack (1.6.8)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails (4.2.10)
+      actionmailer (= 4.2.10)
+      actionpack (= 4.2.10)
+      actionview (= 4.2.10)
+      activejob (= 4.2.10)
+      activemodel (= 4.2.10)
+      activerecord (= 4.2.10)
+      activesupport (= 4.2.10)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 4.2.10)
+      sprockets-rails
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.8)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    railties (4.2.10)
+      actionpack (= 4.2.10)
+      activesupport (= 4.2.10)
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (12.3.0)
+    rbvmomi (1.9.4)
+      builder (~> 3.2)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      trollop (~> 2.1)
+    rly (0.2.3)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-rails (3.5.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    sqlite3 (1.3.12)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    trollop (2.1.2)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2016.9)
+      tzinfo (>= 1.0.0)
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xml-simple (1.1.5)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  capybara
+  fog
+  google-cloud-datastore
+  jquery-rails
+  mysql2 (~> 0.3.0)
+  poltergeist
+  rack-test
+  rails (~> 4.2.8)
+  rspec-rails
+  sqlite3
+  tzinfo-data
+
+BUNDLED WITH
+   1.15.1

--- a/3-cloud-storage-fog/LICENSE
+++ b/3-cloud-storage-fog/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2015 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/3-cloud-storage-fog/README.md
+++ b/3-cloud-storage-fog/README.md
@@ -1,0 +1,90 @@
+# Bookshelf
+
+Checkout branches to view particular steps of this sample application.
+
+ - `1-hello-world`
+ - `2-sql`
+ - `2-datastore`
+ - `3-cloud-storage`
+ - `4-authentication`
+ - `5-logging`
+ - `6-task-queue`
+ - `7-compute-engine`
+
+## 3: Use Cloud Storage
+
+### Setup Google Cloud Storage
+
+Pick a bucket name, it must be globally unique. Replace `<bucket>`
+below with this name. We will create it, and make it globally
+readable with A or B:
+
+A. Command line
+
+    $ gsutil mb gs://<bucket>
+    $ gsutil defacl set public-read gs://<bucket>
+
+B. Web UI
+
+  1. Click "Storage -> Cloud Storage -> Browser" in the left side tree
+  2. Click the blue "Create bucket" button
+  3. Type in the name you picked, click "Create"
+  4. Click on "Buckets" to return to the top level
+  5. On the right of the line of your new bucket, click the three
+     dots, then "Edit object default permissions"
+  6. Click "+ Add item"
+  7. Under ENTITY select "User", Under NAME enter "allUsers", under
+     ACCESS leave it as Reader.
+  8. Click the blue "Save" button.
+
+#### Setup your cloud storage secrets
+
+In the Web UI:
+
+  1. Click "Storage -> Cloud Storage -> Settings" in the left side tree
+  2. Select the "Interoperability" tab
+  3. Click the "Create a new key" button
+
+Setup settings.yml file:
+
+    $ cp config/settings.example.yml config/settings.yml
+
+Edit `settings.yml` and set your `bucket` name and secrets from the Web UI.
+
+### Run
+
+To run the application, first install dependencies:
+
+    $ bundle install
+
+To setup the database for local development, copy the sample `database.yml` file:
+
+    $ cp config/database.example.yml config/database.yml
+
+By default, sqlite is used.  You can edit the `database.yml` to customize your database.
+
+To create the database and run migrations to create the required tables, run:
+
+    $ rake db:migrate
+
+Then, run the Rails web server:
+
+    $ rails server
+
+### To run the tests
+
+    $ bundle install
+    $ rake db:test:prepare
+    $ bundle exec rspec spec/
+
+### To deploy to App Engine Managed VMs
+
+    $ gcloud app deploy
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](LICENSE)

--- a/3-cloud-storage-fog/Rakefile
+++ b/3-cloud-storage-fog/Rakefile
@@ -1,0 +1,19 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require File.expand_path('../config/application', __FILE__)
+
+Rails.application.load_tasks

--- a/3-cloud-storage-fog/app.yaml
+++ b/3-cloud-storage-fog/app.yaml
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START runtime]
+runtime: ruby
+env: flex
+entrypoint: bundle exec rackup -p $PORT
+# [END runtime]

--- a/3-cloud-storage-fog/app/assets/javascripts/application.js
+++ b/3-cloud-storage-fog/app/assets/javascripts/application.js
@@ -1,0 +1,28 @@
+// Copyright 2015, Google, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require jquery
+//= require jquery_ujs
+//= require_tree .

--- a/3-cloud-storage-fog/app/assets/stylesheets/application.css
+++ b/3-cloud-storage-fog/app/assets/stylesheets/application.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any styles
+ * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
+ * file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ */

--- a/3-cloud-storage-fog/app/controllers/application_controller.rb
+++ b/3-cloud-storage-fog/app/controllers/application_controller.rb
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+end

--- a/3-cloud-storage-fog/app/controllers/books_controller.rb
+++ b/3-cloud-storage-fog/app/controllers/books_controller.rb
@@ -1,0 +1,72 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BooksController < ApplicationController
+
+  PER_PAGE = 10
+
+  def index
+    page = params[:more] ? params[:more].to_i : 0
+
+    @books = Book.limit(PER_PAGE).offset PER_PAGE * page
+    @more  = page + 1 if @books.count == PER_PAGE
+  end
+
+  def new
+    @book = Book.new
+  end
+
+  def edit
+    @book = Book.find params[:id]
+  end
+
+  def show
+    @book = Book.find params[:id]
+  end
+
+  def destroy
+    @book = Book.find params[:id]
+    @book.destroy
+    redirect_to books_path
+  end
+
+  def update
+    @book = Book.find params[:id]
+
+    if @book.update book_params
+      flash[:success] = "Updated Book"
+      redirect_to book_path(@book)
+    else
+      render :edit
+    end
+  end
+
+  def create
+    @book = Book.new book_params
+
+    if @book.save
+      flash[:success] = "Added Book"
+      redirect_to book_path(@book)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def book_params
+    params.require(:book).permit :title, :author, :published_on, :description,
+                                 :cover_image
+  end
+
+end

--- a/3-cloud-storage-fog/app/models/book.rb
+++ b/3-cloud-storage-fog/app/models/book.rb
@@ -1,0 +1,67 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START book]
+class Book < ActiveRecord::Base
+  validates :title, presence: true
+
+  attr_accessor :cover_image
+
+  private
+
+  # [START upload]
+  after_create :upload_image, if: :cover_image
+
+  def upload_image
+    image = StorageBucket.files.new(
+      key: "cover_images/#{id}/#{cover_image.original_filename}",
+      body: cover_image.read,
+      public: true
+    )
+
+    image.save
+
+    update_columns image_url: image.public_url
+  end
+  # [END upload]
+
+  # TODO what if the image is from the Pub/Sub job and NOT in Cloud Storage!?
+
+  # [START delete]
+  before_destroy :delete_image, if: :image_url
+
+  def delete_image
+    bucket_name = StorageBucket.key
+    image_uri   = URI.parse image_url
+
+    if image_uri.host == "#{bucket_name}.storage.googleapis.com"
+      # Remove leading forward slash from image path
+      # The result will be the image key, eg. "cover_images/:id/:filename"
+      image_key = image_uri.path.sub("/", "")
+      image     = StorageBucket.files.new key: image_key
+
+      image.destroy
+    end
+  end
+  # [END delete]
+
+  # [START update]
+  before_update :update_image, if: :cover_image
+
+  def update_image
+    delete_image if image_url?
+    upload_image
+  end
+  # [END update]
+end
+# [END book]

--- a/3-cloud-storage-fog/app/views/books/_form.html.erb
+++ b/3-cloud-storage-fog/app/views/books/_form.html.erb
@@ -1,0 +1,52 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<h3>Book</h3>
+
+<% if @book.errors.any? %>
+  <div class="errors">
+    <% @book.errors.full_messages.each do |message| %>
+      <div class="alert alert-danger"><%= message %></div>
+    <% end %>
+  </div>
+<% end %>
+
+<!-- [START multipart] -->
+<%= form_for @book, :html => { :multipart => true } do |f| %>
+<!-- [END multipart] -->
+  <div class="form-group">
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+  <div class="form-group">
+    <%= f.label :author %>
+    <%= f.text_field :author %>
+  </div>
+  <div class="form-group">
+    <%= f.label :published_on, "Date Published" %>
+    <%= f.date_field :published_on %>
+  </div>
+  <div class="form-group">
+    <%= f.label :description %>
+    <%= f.text_area :description %>
+  </div>
+  <!-- [START cover_image] -->
+  <div class="form-group">
+    <%= f.label :cover_image %>
+    <%= f.file_field :cover_image %>
+  </div>
+  <!-- [END cover_image] -->
+  <button class="btn btn-success" type="submit">Save</button>
+<% end %>

--- a/3-cloud-storage-fog/app/views/books/edit.html.erb
+++ b/3-cloud-storage-fog/app/views/books/edit.html.erb
@@ -1,0 +1,16 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<%= render partial: "form" %>

--- a/3-cloud-storage-fog/app/views/books/index.html.erb
+++ b/3-cloud-storage-fog/app/views/books/index.html.erb
@@ -1,0 +1,47 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<h3>Books</h3>
+
+<%= link_to new_book_path, class: "btn btn-success btn-sm" do %>
+  <i class="glyphicon glyphicon-plus"></i>
+  <span>Add Book</span>
+<% end %>
+
+<% @books.each do |book| %>
+  <div class="book media">
+    <%= link_to book_path(book) do %>
+      <div class="media-left">
+        <img src="<%= book.image_url %>">
+      </div>
+      <div class="media-body">
+        <h4><%= book.title %></h4>
+        <p><%= book.author %></p>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @more %>
+  <nav>
+    <ul class="pager">
+      <li><%= link_to "More", books_path(more: @more) %></li>
+    </ul>
+  </nav>
+<% end %>
+
+<% if @books.none? %>
+  <p>No books found.</p>
+<% end %>

--- a/3-cloud-storage-fog/app/views/books/new.html.erb
+++ b/3-cloud-storage-fog/app/views/books/new.html.erb
@@ -1,0 +1,16 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<%= render partial: "form" %>

--- a/3-cloud-storage-fog/app/views/books/show.html.erb
+++ b/3-cloud-storage-fog/app/views/books/show.html.erb
@@ -1,0 +1,42 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<h3>Book</h3>
+
+<div class="btn-group">
+  <%= link_to edit_book_path(@book), class: "btn btn-primary btn-sm" do %>
+    <i class="glyphicon glyphicon-edit"></i>
+    <span>Edit Book</span>
+  <% end %>
+  <%= link_to book_path(@book), class: "btn btn-danger btn-sm", method: :delete do %>
+    <i class="glyphicon glyphicon-trash"></i>
+    <span>Delete Book</span>
+  <% end %>
+</div>
+
+<%# [START book_details] %>
+<div class="media">
+  <!-- [START cover] -->
+  <div class="media-left">
+    <img src="<%= @book.image_url %>">
+  </div>
+  <!-- [END cover] -->
+  <div class="media-body">
+    <h4><%= @book.title %> | &nbsp; <small><%= @book.published_on %></small></h4>
+    <h5>By <%= @book.author || "unknown" %></h5>
+    <p><%= @book.description %></p>
+  </div>
+</div>
+<%# [END book_details] %>

--- a/3-cloud-storage-fog/app/views/layouts/application.html.erb
+++ b/3-cloud-storage-fog/app/views/layouts/application.html.erb
@@ -1,0 +1,46 @@
+<%#
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+%>
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Bookshelf - Ruby on Google Cloud Platform</title>
+    <meta charset="utf-8">
+    <meta name="viewset" content="width=device-width, initial-scale=1">
+    <%= stylesheet_link_tag "//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+    <div class="navbar navbar-default">
+      <div class="container">
+        <div class="navbar-header">
+          <div class="navbar-brand">Bookshelf</div>
+        </div>
+      </div>
+      <ul class="nav navbar-nav">
+        <li><a href="/">Books</a></li>
+      </ul>
+    </div>
+    <div class="container">
+      <% if flash.any? %>
+        <% flash.each do |type, message| %>
+          <div class="alert alert-<%= type %>"><%= message %></div>
+        <% end %>
+      <% end %>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/3-cloud-storage-fog/bin/bundle
+++ b/3-cloud-storage-fog/bin/bundle
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/3-cloud-storage-fog/bin/rails
+++ b/3-cloud-storage-fog/bin/rails
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/3-cloud-storage-fog/bin/rake
+++ b/3-cloud-storage-fog/bin/rake
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run

--- a/3-cloud-storage-fog/bin/setup
+++ b/3-cloud-storage-fog/bin/setup
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle check || bundle install"
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?("config/database.yml")
+  #   system "cp config/database.yml.sample config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system "bin/rake db:setup"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end

--- a/3-cloud-storage-fog/config.ru
+++ b/3-cloud-storage-fog/config.ru
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START rackup]
+# This file is used by Rack-based servers to start the application.
+require ::File.expand_path("../config/environment", __FILE__)
+run Rails.application
+# [END rackup]

--- a/3-cloud-storage-fog/config/application.rb
+++ b/3-cloud-storage-fog/config/application.rb
@@ -1,0 +1,36 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.expand_path("../boot", __FILE__)
+
+require "rails"
+
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module Bookshelf
+  class Application < Rails::Application
+    config.x.settings = Rails.application.config_for :settings
+
+    # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
+  end
+end

--- a/3-cloud-storage-fog/config/boot.rb
+++ b/3-cloud-storage-fog/config/boot.rb
@@ -1,0 +1,16 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+
+require "bundler/setup"

--- a/3-cloud-storage-fog/config/database.example.yml
+++ b/3-cloud-storage-fog/config/database.example.yml
@@ -1,0 +1,40 @@
+default: &default
+# Google Cloud SQL Sample Database Configuration
+# ----------------------------------------------
+#   adapter: mysql2
+#   encoding: utf8
+#   pool: 5
+#   username: [MYSQL_USER]
+#   password: [MYSQL_PASS]
+#   database: [MYSQL_DATABASE]
+#   socket: /cloudsql/[YOUR_INSTANCE_CONNECTION_NAME]
+
+# Google Cloud Datastore Sample Database Configuration
+# ----------------------------------------------------
+#   dataset_id: your-project-id
+
+# PostgreSQL Sample Database Configuration
+# ----------------------------------------
+#   adapter: postgresql
+#   encoding: unicode
+#   pool: 5
+#   username: your-postgresql-user-here
+#   password: your-postgresql-password-here
+#   host: your-postgresql-IPv4-address-here
+#   database: your-postgresql-database-here
+
+development:
+  <<: *default
+
+production:
+  <<: *default
+
+# Test configuration
+test:
+  # Datastore
+  dataset_id: your-test-project-id
+  # SQL
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: db/test.sqlite3

--- a/3-cloud-storage-fog/config/environment.rb
+++ b/3-cloud-storage-fog/config/environment.rb
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Load the Rails application.
+require File.expand_path("../application", __FILE__)
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/3-cloud-storage-fog/config/environments/development.rb
+++ b/3-cloud-storage-fog/config/environments/development.rb
@@ -1,0 +1,36 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  config.serve_static_files = true
+  config.assets.debug = true
+  config.assets.digest = true
+  config.assets.raise_runtime_errors = true
+end

--- a/3-cloud-storage-fog/config/environments/production.rb
+++ b/3-cloud-storage-fog/config/environments/production.rb
@@ -1,0 +1,77 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Serve static files from the `/public` folder by default.
+  # Consider using a CDN for better performance
+  config.serve_static_files = true
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  if Dir.exist? "/var/log/app_engine/custom_logs"
+    config.logger = ActiveSupport::TaggedLogging.new Logger.new("/var/log/app_engine/custom_logs/application.log")
+  end
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  config.assets.compile = false
+  config.assets.digest = true
+end

--- a/3-cloud-storage-fog/config/environments/test.rb
+++ b/3-cloud-storage-fog/config/environments/test.rb
@@ -1,0 +1,50 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # The test environment is used exclusively to run your application's
+  # test suite. You never need to work with it otherwise. Remember that
+  # your test database is "scratch space" for the test suite and is wiped
+  # and recreated between test runs. Don't rely on the data there!
+  config.cache_classes = true
+
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
+  # Configure static file server for tests with Cache-Control for performance.
+  config.serve_static_files   = true
+  config.static_cache_control = 'public, max-age=3600'
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+
+  # Randomize the order test cases are executed.
+  config.active_support.test_order = :random
+
+  # Print deprecation notices to the stderr.
+  config.active_support.deprecation = :stderr
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+end

--- a/3-cloud-storage-fog/config/initializers/assets.rb
+++ b/3-cloud-storage-fog/config/initializers/assets.rb
@@ -1,0 +1,24 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = "1.0"
+
+# Add additional assets to the asset load path
+# Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+# Rails.application.config.assets.precompile += %w( search.js )

--- a/3-cloud-storage-fog/config/initializers/cookies_serializer.rb
+++ b/3-cloud-storage-fog/config/initializers/cookies_serializer.rb
@@ -1,0 +1,16 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/3-cloud-storage-fog/config/initializers/filter_parameter_logging.rb
+++ b/3-cloud-storage-fog/config/initializers/filter_parameter_logging.rb
@@ -1,0 +1,17 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+# Configure sensitive parameters which will be filtered from the log file.
+Rails.application.config.filter_parameters += [:password]

--- a/3-cloud-storage-fog/config/initializers/fog_cloud_storage.rb
+++ b/3-cloud-storage-fog/config/initializers/fog_cloud_storage.rb
@@ -1,0 +1,39 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if Rails.env.test?
+
+  Fog.mock!
+  FogStorage = Fog::Storage.new(
+    provider: "Google",
+    google_storage_access_key_id: "mock",
+    google_storage_secret_access_key: "mock"
+  )
+  FogStorage.directories.create key: "testbucket", acl: "public-read"
+  StorageBucket = FogStorage.directories.get "testbucket"
+
+else
+
+  # [START fog_storage]
+  config = Rails.application.config.x.settings["cloud_storage"]
+
+  FogStorage = Fog::Storage.new(
+    provider: "Google",
+    google_storage_access_key_id:     config["access_key_id"],
+    google_storage_secret_access_key: config["secret_access_key"]
+  )
+
+  StorageBucket = FogStorage.directories.new key: config["bucket"]
+  # [END fog_storage]
+
+end

--- a/3-cloud-storage-fog/config/initializers/inflections.rb
+++ b/3-cloud-storage-fog/config/initializers/inflections.rb
@@ -1,0 +1,29 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+# Add new inflection rules using the following format. Inflections
+# are locale specific, and you may define rules for as many different
+# locales as you wish. All of these examples are active by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.plural /^(ox)$/i, '\1en'
+#   inflect.singular /^(ox)en/i, '\1'
+#   inflect.irregular 'person', 'people'
+#   inflect.uncountable %w( fish sheep )
+# end
+
+# These inflection rules are supported but not enabled by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.acronym 'RESTful'
+# end

--- a/3-cloud-storage-fog/config/initializers/session_store.rb
+++ b/3-cloud-storage-fog/config/initializers/session_store.rb
@@ -1,0 +1,16 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.session_store :cookie_store, key: '_Bookshelf_session'

--- a/3-cloud-storage-fog/config/initializers/wrap_parameters.rb
+++ b/3-cloud-storage-fog/config/initializers/wrap_parameters.rb
@@ -1,0 +1,22 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+# This file contains settings for ActionController::ParamsWrapper which
+# is enabled by default.
+
+# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
+end

--- a/3-cloud-storage-fog/config/routes.rb
+++ b/3-cloud-storage-fog/config/routes.rb
@@ -1,0 +1,24 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START routes]
+Rails.application.routes.draw do
+
+  # Route root of application to BooksController#index action
+  root "books#index"
+
+  # Restful routes for BooksController
+  resources :books
+
+end
+# [END routes]

--- a/3-cloud-storage-fog/config/secrets.yml
+++ b/3-cloud-storage-fog/config/secrets.yml
@@ -1,0 +1,33 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: db5c071ac181d90e429e9b3b9178f6ff2fbf6a9a68576dd666d85faa0aa9e3e4db59991e24a2a723524e42c1dbc61f0bf1a77451d43569d46f0e3c16b59170e3
+
+test:
+  secret_key_base: c2b72729ddf4d841a9e2225b3233f6eb3b42fc8d2585db157161ed44e7760fbec64a694434573b5e5c7fbb20ae5969cfb13198d3dec19242e7d2eb3750406b24
+
+production:
+  secret_key_base: 3659d9ac716f22a88f4235cae7c33e9a994492fb0dd5704350863c8bb8cc34571e568651578784185f2ea94a660769e586e72008fb801127df045b4aa4abb0ba

--- a/3-cloud-storage-fog/config/settings.example.yml
+++ b/3-cloud-storage-fog/config/settings.example.yml
@@ -1,0 +1,11 @@
+default: &default
+  cloud_storage:
+    bucket: your-bucket-name
+    access_key_id: your-access-key-id
+    secret_access_key: your-secret-access-key
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/3-cloud-storage-fog/db/migrate/20150706182833_create_books.rb
+++ b/3-cloud-storage-fog/db/migrate/20150706182833_create_books.rb
@@ -1,0 +1,27 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START migration]
+class CreateBooks < ActiveRecord::Migration
+  def change
+    create_table :books do |t|
+      t.string :title, required: true
+      t.string :author
+      t.date :published_on
+      t.text :description
+
+      t.timestamps null: false
+    end
+  end
+end
+# [END migration]

--- a/3-cloud-storage-fog/db/migrate/20150805182908_add_image_url_to_books.rb
+++ b/3-cloud-storage-fog/db/migrate/20150805182908_add_image_url_to_books.rb
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class AddImageUrlToBooks < ActiveRecord::Migration
+  def change
+    add_column :books, :image_url, :string
+  end
+end

--- a/3-cloud-storage-fog/db/schema.rb
+++ b/3-cloud-storage-fog/db/schema.rb
@@ -1,0 +1,26 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150805182908) do
+
+  create_table "books", force: :cascade do |t|
+    t.string   "title"
+    t.string   "author"
+    t.date     "published_on"
+    t.text     "description"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.string   "image_url"
+  end
+
+end

--- a/3-cloud-storage-fog/lib/tasks/backend.rake
+++ b/3-cloud-storage-fog/lib/tasks/backend.rake
@@ -1,0 +1,30 @@
+require "fileutils"
+
+namespace :backend do
+
+  BACKEND_FILES = %w[
+    config/application.rb
+    app/models/book.rb
+    app/controllers/books_controller.rb
+  ]
+
+  def use_backend name
+    backend_root = "structured_data/#{name}"
+
+    BACKEND_FILES.each do |file|
+      puts "#{backend_root}/#{file} -> #{file}"
+      FileUtils.cp Rails.root.join(backend_root, file), Rails.root.join(file)
+    end
+  end
+
+  desc "Use Google Cloud Datastore backend"
+  task datastore: :environment do
+    use_backend :datastore
+  end
+
+  desc "Use ActiveRecord SQL database backend"
+  task active_record: :environment do
+    use_backend :active_record
+  end
+
+end

--- a/3-cloud-storage-fog/public/404.html
+++ b/3-cloud-storage-fog/public/404.html
@@ -1,0 +1,82 @@
+<!--
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>The page you were looking for doesn't exist (404)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/404.html -->
+  <div class="dialog">
+    <div>
+      <h1>The page you were looking for doesn't exist.</h1>
+      <p>You may have mistyped the address or the page may have moved.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/3-cloud-storage-fog/public/422.html
+++ b/3-cloud-storage-fog/public/422.html
@@ -1,0 +1,82 @@
+<!--
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>The change you wanted was rejected (422)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/422.html -->
+  <div class="dialog">
+    <div>
+      <h1>The change you wanted was rejected.</h1>
+      <p>Maybe you tried to change something you didn't have access to.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/3-cloud-storage-fog/public/500.html
+++ b/3-cloud-storage-fog/public/500.html
@@ -1,0 +1,81 @@
+<!--
+  Copyright 2015, Google, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/500.html -->
+  <div class="dialog">
+    <div>
+      <h1>We're sorry, but something went wrong.</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/3-cloud-storage-fog/public/robots.txt
+++ b/3-cloud-storage-fog/public/robots.txt
@@ -1,0 +1,18 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# To ban all spiders from the entire site uncomment the next two lines:
+# User-agent: *
+# Disallow: /

--- a/3-cloud-storage-fog/spec/datastore_book_extensions.rb
+++ b/3-cloud-storage-fog/spec/datastore_book_extensions.rb
@@ -1,0 +1,91 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Additional methods added to the Book class for testing only.
+#
+# Implements API similar to ActiveRecord for shared SQL/Datastore test suite.
+module DatastoreBookExtensions
+
+  def self.included base
+    base.send :extend, ClassMethods
+  end
+
+  def reload
+    book = Book.find id
+    self.title        = book.title
+    self.author       = book.author
+    self.published_on = book.published_on
+    self.description  = book.description
+    self.image_url    = book.image_url
+    book
+  end
+
+  module ClassMethods
+
+    def all
+      books = []
+
+      query = Google::Cloud::Datastore::Query.new.kind "Book"
+
+      loop do
+        results = dataset.run query
+
+        if results.empty?
+          break
+        else
+          results.each {|entity| books << from_entity(entity) }
+          query.cursor results.cursor
+          results = dataset.run query
+        end
+      end
+
+      books
+    end
+
+    def first
+      all.first
+    end
+
+    def count
+      all.length
+    end
+
+    def delete_all
+      query = Google::Cloud::Datastore::Query.new.kind "Book"
+      loop do
+        books = dataset.run query
+        if books.empty?
+          break
+        else
+          dataset.delete *books
+        end
+      end
+    end
+
+    def exists? id
+      find(id).present?
+    end
+
+    def create attributes = nil
+      book = Book.new attributes
+      book.save
+      book
+    end
+
+    def create! attributes = nil
+      book = Book.new attributes
+      raise "Book save failed" unless book.save
+      book
+    end
+  end
+end

--- a/3-cloud-storage-fog/spec/features/book_management_e2e_spec.rb
+++ b/3-cloud-storage-fog/spec/features/book_management_e2e_spec.rb
@@ -1,0 +1,50 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+
+feature "Managing Books" do
+
+  scenario "Adding a book with missing fields (e2e)", :e2e => true do
+    visit E2E.url + root_path
+    click_link "Add Book"
+    within "form.new_book" do
+      click_button "Save"
+    end
+
+    expect(page).to have_content "Title can't be blank"
+  end
+
+  scenario "Adding/List/Delete a book (e2e)", :e2e => true do
+    visit E2E.url + root_path
+    click_link "Add Book"
+    within "form.new_book" do
+      fill_in "Title", with: "A Tale of Two Cities"
+      fill_in "Author", with: "Charles Dickens"
+      fill_in "Date Published", with: "1859-04-01"
+      fill_in "Description", with: "A novel by Charles Dickens"
+      click_button "Save"
+    end
+    expect(page).to have_content "Added Book"
+
+    visit E2E.url + root_path
+    expect(page).to have_content "A Tale of Two Cities"
+    expect(page).to have_content "Charles Dickens"
+
+    visit E2E.url + root_path
+    first(:link, "A Tale of Two Cities").click
+    click_link "Delete Book"
+    expect(current_path).to eq '/books'
+  end
+
+end

--- a/3-cloud-storage-fog/spec/features/book_management_spec.rb
+++ b/3-cloud-storage-fog/spec/features/book_management_spec.rb
@@ -1,0 +1,240 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+
+feature "Managing Books" do
+
+  scenario "No books have been added" do
+    visit root_path
+
+    expect(page).to have_content "No books found"
+  end
+
+  scenario "Listing all books" do
+    Book.create! title: "A Tale of Two Cities", author: "Charles Dickens"
+
+    visit root_path
+
+    expect(page).to have_content "A Tale of Two Cities"
+    expect(page).to have_content "Charles Dickens"
+  end
+
+  scenario "Paginating through list of books" do
+    Book.create! title: "Book 1"
+    Book.create! title: "Book 2"
+    Book.create! title: "Book 3"
+    Book.create! title: "Book 4"
+    Book.create! title: "Book 5"
+
+    stub_const "BooksController::PER_PAGE", 2
+
+    visit root_path
+    expect(all(".book").length).to eq 2
+
+    click_link "More"
+    expect(all(".book").length).to eq 2
+
+    click_link "More"
+    expect(all(".book").length).to eq 1
+
+    expect(page).not_to have_link "More"
+  end
+
+  scenario "Displaying a book" do
+    Book.create! title: "A Tale of Two Cities",
+                 author: "Charles Dickens",
+                 published_on: "2015-01-01",
+                 description: "This is a book!"
+
+    visit root_path
+    click_link "A Tale of Two Cities"
+
+    expect(page).to have_css "h4", text: "A Tale of Two Cities | 2015-01-01"
+    expect(page).to have_css "h5", text: "By Charles Dickens"
+    expect(page).to have_css "p", text: "This is a book!"
+  end
+
+  scenario "Displaying a book with an unknown author" do
+    book = Book.create! title: "A Tale of Two Cities"
+
+    visit book_path(book)
+
+    expect(page).to have_css "h5", text: "By unknown"
+  end
+
+  scenario "Adding a book" do
+    visit root_path
+    click_link "Add Book"
+    within "form.new_book" do
+      fill_in "Title", with: "A Tale of Two Cities"
+      fill_in "Author", with: "Charles Dickens"
+      fill_in "Date Published", with: "1859-04-01"
+      fill_in "Description", with: "A novel by Charles Dickens"
+      click_button "Save"
+    end
+
+    expect(page).to have_content "Added Book"
+
+    book = Book.first
+    expect(book.title).to eq "A Tale of Two Cities"
+    expect(book.author).to eq "Charles Dickens"
+    expect(book.published_on.to_date).to eq Date.parse("1859-04-01")
+    expect(book.description).to eq "A novel by Charles Dickens"
+  end
+
+  scenario "Adding a book with missing fields" do
+    visit root_path
+    click_link "Add Book"
+    within "form.new_book" do
+      click_button "Save"
+    end
+
+    expect(page).to have_content "Title can't be blank"
+    expect(Book.count).to eq 0
+
+    within "form.new_book" do
+      fill_in "Title", with: "A Tale of Two Cities"
+      click_button "Save"
+    end
+
+    expect(Book.first.title).to eq "A Tale of Two Cities"
+  end
+
+  scenario "Editing a book" do
+    book = Book.create! title: "A Tale of Two Cities", author: "Charles Dickens"
+
+    visit root_path
+    click_link "A Tale of Two Cities"
+    click_link "Edit Book"
+    fill_in "Title", with: "CHANGED!"
+    click_button "Save"
+
+    expect(page).to have_content "Updated Book"
+
+    book = Book.find book.id
+    expect(book.title).to eq "CHANGED!"
+    expect(book.author).to eq "Charles Dickens"
+  end
+
+  scenario "Editing a book with missing fields" do
+    book = Book.create! title: "A Tale of Two Cities"
+
+    visit root_path
+    click_link "A Tale of Two Cities"
+    click_link "Edit Book"
+    fill_in "Title", with: ""
+    click_button "Save"
+
+    expect(page).to have_content "Title can't be blank"
+    book.reload
+    expect(book.title).to eq "A Tale of Two Cities"
+
+    within "form.edit_book" do
+      fill_in "Title", with: "CHANGED!"
+      click_button "Save"
+    end
+
+    book = Book.find book.id
+    expect(book.title).to eq "CHANGED!"
+  end
+
+  scenario "Deleting a book" do
+    book = Book.create! title: "A Tale of Two Cities", author: "Charles Dickens"
+    expect(Book.exists? book.id).to be true
+
+    visit root_path
+    click_link "A Tale of Two Cities"
+    click_link "Delete Book"
+
+    expect(Book.exists? book.id).to be false
+  end
+
+  feature "with Cover Images" do
+
+    scenario "Displaying cover images in book listing" do
+      book = Book.create! title: "A Tale of Two Cities",
+                          cover_image: Rack::Test::UploadedFile.new("spec/resources/test.txt")
+
+      visit root_path
+
+      expect(page).to have_content "A Tale of Two Cities"
+      expect(page).to have_css "img[src='#{book.image_url}']"
+    end
+
+    scenario "Displaying cover image on book page" do
+      book = Book.create! title: "A Tale of Two Cities",
+                          cover_image: Rack::Test::UploadedFile.new("spec/resources/test.txt")
+
+      visit book_path(book)
+
+      expect(page).to have_css "img[src='#{book.image_url}']"
+    end
+
+    scenario "Adding a book with an image" do
+      visit root_path
+      click_link "Add Book"
+      within "form.new_book" do
+        fill_in "Title", with: "A Tale of Two Cities"
+        attach_file "Cover image", "spec/resources/test.txt"
+        click_button "Save"
+      end
+
+      expect(page).to have_content "Added Book"
+      expect(Book.count).to eq 1
+
+      book = Book.first
+      expect(book.title).to eq "A Tale of Two Cities"
+      expect(book.image_url).to end_with "/cover_images/#{book.id}/test.txt"
+
+      expect(StorageBucket.files.all.count).to eq 1
+      file = StorageBucket.files.first
+      expect(file.key).to eq "cover_images/#{book.id}/test.txt"
+      expect(file.body).to include "Test file."
+    end
+
+    scenario "Editing a book's cover image" do
+      book = Book.create! title: "A Tale of Two Cities",
+                          cover_image: Rack::Test::UploadedFile.new("spec/resources/test.txt")
+
+      visit root_path
+      click_link "A Tale of Two Cities"
+      click_link "Edit Book"
+      attach_file "Cover image", "spec/resources/test-2.txt"
+      click_button "Save"
+
+      expect(page).to have_content "Updated Book"
+      expect(StorageBucket.files.get "cover_images/#{book.id}/test-2.txt").to be_present
+      expect(StorageBucket.files.get "cover_images/#{book.id}/test.txt").to be_nil
+
+      book.reload
+      expect(book.image_url).to end_with "/cover_images/#{book.id}/test-2.txt"
+    end
+
+    scenario "Deleting a book with an image" do
+      book = Book.create! title: "A Tale of Two Cities",
+                          cover_image: Rack::Test::UploadedFile.new("spec/resources/test.txt")
+
+      image_key = "cover_images/#{book.id}/test.txt"
+      expect(StorageBucket.files.get image_key).to be_present
+
+      visit root_path
+      click_link "A Tale of Two Cities"
+      click_link "Delete Book"
+
+      expect(Book.exists? book.id).to be false
+      expect(StorageBucket.files.get image_key).to be_nil
+    end
+
+  end
+end

--- a/3-cloud-storage-fog/spec/models/book_spec.rb
+++ b/3-cloud-storage-fog/spec/models/book_spec.rb
@@ -1,0 +1,23 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "spec_helper"
+
+RSpec.describe Book do
+
+  it "requires a title" do
+    expect(Book.new title: nil).not_to be_valid
+    expect(Book.new title: "title").to be_valid
+  end
+
+end

--- a/3-cloud-storage-fog/spec/resources/test-2.txt
+++ b/3-cloud-storage-fog/spec/resources/test-2.txt
@@ -1,0 +1,1 @@
+Test file 2.

--- a/3-cloud-storage-fog/spec/resources/test.txt
+++ b/3-cloud-storage-fog/spec/resources/test.txt
@@ -1,0 +1,1 @@
+Test file.

--- a/3-cloud-storage-fog/spec/spec_helper.rb
+++ b/3-cloud-storage-fog/spec/spec_helper.rb
@@ -1,0 +1,47 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV["RAILS_ENV"] ||= "test"
+
+require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path("../../../spec/e2e", __FILE__)
+require "rspec/rails"
+require "capybara/rails"
+require 'capybara/poltergeist'
+require "rack/test"
+
+if Book.respond_to? :dataset
+  require "datastore_book_extensions"
+  Book.send :include, DatastoreBookExtensions
+end
+
+Rails.configuration.x.fog_dir = "testbucket"
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+
+  config.infer_spec_type_from_file_location!
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.before :each do
+    Book.delete_all
+    Fog::Mock.reset
+    FogStorage.directories.create key: "testbucket", acl: "public-read"
+  end
+
+  E2E.register_config(config)
+  E2E.register_cleanup(config)
+end

--- a/3-cloud-storage-fog/structured_data/active_record/app/controllers/books_controller.rb
+++ b/3-cloud-storage-fog/structured_data/active_record/app/controllers/books_controller.rb
@@ -1,0 +1,72 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BooksController < ApplicationController
+
+  PER_PAGE = 10
+
+  def index
+    page = params[:more] ? params[:more].to_i : 0
+
+    @books = Book.limit(PER_PAGE).offset PER_PAGE * page
+    @more  = page + 1 if @books.count == PER_PAGE
+  end
+
+  def new
+    @book = Book.new
+  end
+
+  def edit
+    @book = Book.find params[:id]
+  end
+
+  def show
+    @book = Book.find params[:id]
+  end
+
+  def destroy
+    @book = Book.find params[:id]
+    @book.destroy
+    redirect_to books_path
+  end
+
+  def update
+    @book = Book.find params[:id]
+
+    if @book.update book_params
+      flash[:success] = "Updated Book"
+      redirect_to book_path(@book)
+    else
+      render :edit
+    end
+  end
+
+  def create
+    @book = Book.new book_params
+
+    if @book.save
+      flash[:success] = "Added Book"
+      redirect_to book_path(@book)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def book_params
+    params.require(:book).permit :title, :author, :published_on, :description,
+                                 :cover_image
+  end
+
+end

--- a/3-cloud-storage-fog/structured_data/active_record/app/models/book.rb
+++ b/3-cloud-storage-fog/structured_data/active_record/app/models/book.rb
@@ -1,0 +1,67 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START book]
+class Book < ActiveRecord::Base
+  validates :title, presence: true
+
+  attr_accessor :cover_image
+
+  private
+
+  # [START upload]
+  after_create :upload_image, if: :cover_image
+
+  def upload_image
+    image = StorageBucket.files.new(
+      key: "cover_images/#{id}/#{cover_image.original_filename}",
+      body: cover_image.read,
+      public: true
+    )
+
+    image.save
+
+    update_columns image_url: image.public_url
+  end
+  # [END upload]
+
+  # TODO what if the image is from the Pub/Sub job and NOT in Cloud Storage!?
+
+  # [START delete]
+  before_destroy :delete_image, if: :image_url
+
+  def delete_image
+    bucket_name = StorageBucket.key
+    image_uri   = URI.parse image_url
+
+    if image_uri.host == "#{bucket_name}.storage.googleapis.com"
+      # Remove leading forward slash from image path
+      # The result will be the image key, eg. "cover_images/:id/:filename"
+      image_key = image_uri.path.sub("/", "")
+      image     = StorageBucket.files.new key: image_key
+
+      image.destroy
+    end
+  end
+  # [END delete]
+
+  # [START update]
+  before_update :update_image, if: :cover_image
+
+  def update_image
+    delete_image if image_url?
+    upload_image
+  end
+  # [END update]
+end
+# [END book]

--- a/3-cloud-storage-fog/structured_data/active_record/config/application.rb
+++ b/3-cloud-storage-fog/structured_data/active_record/config/application.rb
@@ -1,0 +1,36 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.expand_path("../boot", __FILE__)
+
+require "rails"
+
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module Bookshelf
+  class Application < Rails::Application
+    config.x.settings = Rails.application.config_for :settings
+
+    # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.raise_in_transactional_callbacks = true
+  end
+end

--- a/3-cloud-storage-fog/structured_data/datastore/app/controllers/books_controller.rb
+++ b/3-cloud-storage-fog/structured_data/datastore/app/controllers/books_controller.rb
@@ -1,0 +1,77 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BooksController < ApplicationController
+
+  PER_PAGE = 10
+
+  def index
+    @books, @more = Book.query limit: PER_PAGE, cursor: params[:more]
+  end
+
+  def new
+    @book = Book.new
+  end
+
+  def show
+    @book = Book.find params[:id]
+  end
+
+  def edit
+    @book = Book.find params[:id]
+  end
+
+  def update
+    @book = Book.find params[:id]
+
+    if @book.update book_params
+      flash[:success] = "Updated Book"
+      redirect_to book_path(@book)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @book = Book.find params[:id]
+    @book.destroy
+    redirect_to books_path
+  end
+
+  before_filter :convert_published_on_to_date
+
+  def create
+    @book = Book.new book_params
+
+    if @book.save
+      flash[:success] = "Added Book"
+      redirect_to book_path(@book)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def book_params
+    params.require(:book).permit :title, :author, :published_on, :description,
+                                 :cover_image
+  end
+
+  def convert_published_on_to_date
+    if params[:book] && params[:book][:published_on].present?
+      params[:book][:published_on] = Time.parse params[:book][:published_on]
+    end
+  end
+
+end

--- a/3-cloud-storage-fog/structured_data/datastore/app/models/book.rb
+++ b/3-cloud-storage-fog/structured_data/datastore/app/models/book.rb
@@ -1,0 +1,145 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/datastore"
+
+class Book
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :id, :title, :author, :published_on, :description, :image_url,
+                :cover_image
+
+
+  validates :title, presence: true
+
+  # Return a Google::Cloud::Datastore::Dataset for the configured dataset.
+  # The dataset is used to create, read, update, and delete entity objects.
+  def self.dataset
+    @dataset ||= Google::Cloud::Datastore.new(
+      project: Rails.application.config.
+                     database_configuration[Rails.env]["dataset_id"]
+    )
+  end
+
+  # Query Book entities from Cloud Datastore.
+  #
+  # returns an array of Book query results and a cursor
+  # that can be used to query for additional results.
+  def self.query options = {}
+    query = Google::Cloud::Datastore::Query.new
+    query.kind "Book"
+    query.limit options[:limit]   if options[:limit]
+    query.cursor options[:cursor] if options[:cursor]
+
+    results = dataset.run query
+    books   = results.map {|entity| Book.from_entity entity }
+
+    if options[:limit] && results.size == options[:limit]
+      next_cursor = results.cursor
+    end
+
+    return books, next_cursor
+  end
+
+  def self.from_entity entity
+    book = Book.new
+    book.id = entity.key.id
+    entity.properties.to_hash.each do |name, value|
+      book.send "#{name}=", value if book.respond_to? "#{name}="
+    end
+    book
+  end
+
+  # Lookup Book by ID.  Returns Book or nil.
+  def self.find id
+    query    = Google::Cloud::Datastore::Key.new "Book", id.to_i
+    entities = dataset.lookup query
+
+    from_entity entities.first if entities.any?
+  end
+
+  def save
+    if valid?
+      entity = to_entity
+      Book.dataset.save entity
+      self.id = entity.key.id
+      update_image if cover_image.present?
+      true
+    else
+      false
+    end
+  end
+
+  def to_entity
+    entity = Google::Cloud::Datastore::Entity.new
+    entity.key = Google::Cloud::Datastore::Key.new "Book", id
+    entity["title"]        = title
+    entity["author"]       = author       if author
+    entity["published_on"] = published_on if published_on
+    entity["description"]  = description  if description
+    entity["image_url"]    = image_url    if image_url
+    entity
+  end
+
+  def update attributes
+    attributes.each do |name, value|
+      send "#{name}=", value
+    end
+    save
+  end
+
+  def destroy
+    delete_image if image_url.present?
+
+    Book.dataset.delete Google::Cloud::Datastore::Key.new "Book", id
+  end
+
+  def persisted?
+    id.present?
+  end
+
+  def upload_image
+    image = StorageBucket.files.new(
+      key: "cover_images/#{id}/#{cover_image.original_filename}",
+      body: cover_image.read,
+      public: true
+    )
+
+    image.save
+
+    self.image_url = image.public_url
+
+    Book.dataset.save to_entity
+  end
+
+  def delete_image
+    bucket_name = StorageBucket.key
+    image_uri   = URI.parse image_url
+
+    if image_uri.host == "#{bucket_name}.storage.googleapis.com"
+      # Remove leading forward slash from image path
+      # The result will be the image key, eg. "cover_images/:id/:filename"
+      image_key = image_uri.path.sub("/", "")
+      image     = StorageBucket.files.new key: image_key
+
+      image.destroy
+    end
+  end
+
+  def update_image
+    delete_image if image_url.present?
+    upload_image
+  end
+
+end

--- a/3-cloud-storage-fog/structured_data/datastore/config/application.rb
+++ b/3-cloud-storage-fog/structured_data/datastore/config/application.rb
@@ -1,0 +1,32 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.expand_path("../boot", __FILE__)
+
+require "rails"
+
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module Bookshelf
+  class Application < Rails::Application
+    config.x.settings = Rails.application.config_for :settings
+  end
+end


### PR DESCRIPTION
Copy the `3-cloud-storage` tutorial to a new directory `3-cloud-storage-fog`. Afterwards, we will point the existing fog-based tutorial text to this new directory, which will free us to make changes to the original directory to migrate to the veneer clients.