### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Checkout folders to view particular steps of this sample application.
 
 [Ruby on Rails][ror] web application on [Google App Engine][gae].
 
+### Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=ruby).
+
 ### Run
 
 To run the application, first install dependencies:


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.

This is for the benefit of the users, in navigating available Google Cloud code samples.